### PR TITLE
Use platforms for roborio_toolchain, lint bazel files with buildifier

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,3 +1,3 @@
-build:roborio --crosstool_top=//third_party/roborio_toolchain:roborio_toolchain_suite
+build:roborio --platforms=//platforms:roborio
+build:roborio --incompatible_enable_cc_toolchain_resolution
 build:roborio --experimental_use_sandboxfs
-

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,69 +1,79 @@
 workspace(name = "FRC_IPC")
 
-load('@bazel_tools//tools/build_defs/repo:git.bzl', 'git_repository', 'new_git_repository')
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository", "new_git_repository")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
+register_toolchains(
+    "//third_party/roborio_toolchain:roborio_toolchain_darwin",
+    "//third_party/roborio_toolchain:roborio_toolchain_linux",
+    "//third_party/roborio_toolchain:roborio_toolchain_windows",
+)
+
 WPILIB_VERSION = "2020.2.2"
+
 NI_LIB_VERSION = "2020.9.2"
+
 CTRE_LIB_VERSION = "5.16.0"
+
 OPEN_CV_VERSION = "3.4.7-2"
+
 EIGEN_VERSION = "3.3.7"
 
 git_repository(
-    name="com_github_google_flatbuffers",
-    tag="v1.10.0",
-    init_submodules=True,
-    remote = "https://github.com/google/flatbuffers.git"
+    name = "com_github_google_flatbuffers",
+    init_submodules = True,
+    remote = "https://github.com/google/flatbuffers.git",
+    tag = "v1.10.0",
 )
 
 git_repository(
-    name="gtest",
-    tag="release-1.8.1",
-    init_submodules=True,
-    remote = "https://github.com/google/googletest.git"
+    name = "gtest",
+    init_submodules = True,
+    remote = "https://github.com/google/googletest.git",
+    tag = "release-1.8.1",
 )
 
 http_archive(
     name = "io_bazel_rules_go",
+    sha256 = "af04c969321e8f428f63ceb73463d6ea817992698974abeff0161e069cd08bd6",
     urls = [
         "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.21.3/rules_go-v0.21.3.tar.gz",
         "https://github.com/bazelbuild/rules_go/releases/download/v0.21.3/rules_go-v0.21.3.tar.gz",
     ],
-    sha256 = "af04c969321e8f428f63ceb73463d6ea817992698974abeff0161e069cd08bd6",
 )
 
-load("@io_bazel_rules_go//go:deps.bzl", "go_rules_dependencies", "go_register_toolchains")
+load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
 
 go_rules_dependencies()
 
 go_register_toolchains()
 
 new_git_repository(
-    name="eigen",
-    remote="https://gitlab.com/libeigen/eigen.git",
-    tag="{}".format(EIGEN_VERSION),
-    build_file = "//third_party/eigen:eigen.BUILD"
+    name = "eigen",
+    build_file = "//third_party/eigen:eigen.BUILD",
+    remote = "https://gitlab.com/libeigen/eigen.git",
+    tag = "{}".format(EIGEN_VERSION),
 )
 
 new_git_repository(
     name = "libzmq",
+    build_file = "//third_party/zeromq:libzmq.BUILD",
     remote = "https://github.com/zeromq/libzmq.git",
     tag = "v4.3.2",
-    build_file = "//third_party/zeromq:libzmq.BUILD"
 )
 
 new_git_repository(
     name = "cppzmq",
+    build_file = "//third_party/zeromq:cppzmq.BUILD",
     remote = "https://github.com/zeromq/cppzmq.git",
     tag = "v4.6.0",
-    build_file = "//third_party/zeromq:cppzmq.BUILD"
 )
 
 new_git_repository(
-    name="pyzmq",
-    remote="https://github.com/zeromq/pyzmq.git",
-    tag="v18.1.1",
-    build_file = "//third_party/zeromq:pyzmq.BUILD"
+    name = "pyzmq",
+    build_file = "//third_party/zeromq:pyzmq.BUILD",
+    remote = "https://github.com/zeromq/pyzmq.git",
+    tag = "v18.1.1",
 )
 
 hdrs_content = """
@@ -80,175 +90,204 @@ cc_library(
 """
 
 http_archive(
-    name="wpilibc_hdrs",
-    urls=["https://frcmaven.wpi.edu/artifactory/release/edu/wpi/first/wpilibc/wpilibc-cpp/{0}/wpilibc-cpp-{0}-headers.zip".format(WPILIB_VERSION)],
-    build_file_content=hdrs_content,
+    name = "wpilibc_hdrs",
+    build_file_content = hdrs_content,
+    urls = ["https://frcmaven.wpi.edu/artifactory/release/edu/wpi/first/wpilibc/wpilibc-cpp/{0}/wpilibc-cpp-{0}-headers.zip".format(WPILIB_VERSION)],
 )
 
 http_archive(
-    name="wpilibc",
-    urls=["https://frcmaven.wpi.edu/artifactory/release/edu/wpi/first/wpilibc/wpilibc-cpp/{0}/wpilibc-cpp-{0}-linuxathenastatic.zip".format(WPILIB_VERSION)],
-    build_file="//third_party/wpilibsuite:wpilibc.BUILD",
+    name = "wpilibc",
+    build_file = "//third_party/wpilibsuite:wpilibc.BUILD",
+    urls = ["https://frcmaven.wpi.edu/artifactory/release/edu/wpi/first/wpilibc/wpilibc-cpp/{0}/wpilibc-cpp-{0}-linuxathenastatic.zip".format(WPILIB_VERSION)],
 )
 
 http_archive(
-    name="hal_hdrs",
-    urls=["https://frcmaven.wpi.edu/artifactory/release/edu/wpi/first/hal/hal-cpp/{0}/hal-cpp-{0}-headers.zip".format(WPILIB_VERSION)],
-    build_file_content=hdrs_content,
+    name = "hal_hdrs",
+    build_file_content = hdrs_content,
+    urls = ["https://frcmaven.wpi.edu/artifactory/release/edu/wpi/first/hal/hal-cpp/{0}/hal-cpp-{0}-headers.zip".format(WPILIB_VERSION)],
 )
 
 http_archive(
-    name="hal",
-    urls=["https://frcmaven.wpi.edu/artifactory/release/edu/wpi/first/hal/hal-cpp/{0}/hal-cpp-{0}-linuxathenastatic.zip".format(WPILIB_VERSION)],
-    build_file="//third_party/wpilibsuite:hal.BUILD",
+    name = "hal",
+    build_file = "//third_party/wpilibsuite:hal.BUILD",
+    urls = ["https://frcmaven.wpi.edu/artifactory/release/edu/wpi/first/hal/hal-cpp/{0}/hal-cpp-{0}-linuxathenastatic.zip".format(WPILIB_VERSION)],
 )
 
 http_archive(
-    name="wpiutil_hdrs",
-    urls=["https://frcmaven.wpi.edu/artifactory/release/edu/wpi/first/wpiutil/wpiutil-cpp/{0}/wpiutil-cpp-{0}-headers.zip".format(WPILIB_VERSION)],
-    build_file_content=hdrs_content,
+    name = "wpiutil_hdrs",
+    build_file_content = hdrs_content,
+    urls = ["https://frcmaven.wpi.edu/artifactory/release/edu/wpi/first/wpiutil/wpiutil-cpp/{0}/wpiutil-cpp-{0}-headers.zip".format(WPILIB_VERSION)],
 )
 
 http_archive(
-    name="wpiutil",
-    urls=["https://frcmaven.wpi.edu/artifactory/release/edu/wpi/first/wpiutil/wpiutil-cpp/{0}/wpiutil-cpp-{0}-linuxathenastatic.zip".format(WPILIB_VERSION)],
-    build_file="//third_party/wpilibsuite:wpiutil.BUILD",
+    name = "wpiutil",
+    build_file = "//third_party/wpilibsuite:wpiutil.BUILD",
+    urls = ["https://frcmaven.wpi.edu/artifactory/release/edu/wpi/first/wpiutil/wpiutil-cpp/{0}/wpiutil-cpp-{0}-linuxathenastatic.zip".format(WPILIB_VERSION)],
 )
 
 http_archive(
-    name="ntcore_hdrs",
-    urls=["https://frcmaven.wpi.edu/artifactory/release/edu/wpi/first/ntcore/ntcore-cpp/{0}/ntcore-cpp-{0}-headers.zip".format(WPILIB_VERSION)],
-    build_file_content=hdrs_content,
+    name = "ntcore_hdrs",
+    build_file_content = hdrs_content,
+    urls = ["https://frcmaven.wpi.edu/artifactory/release/edu/wpi/first/ntcore/ntcore-cpp/{0}/ntcore-cpp-{0}-headers.zip".format(WPILIB_VERSION)],
 )
 
 http_archive(
-    name="ntcore",
-    urls=["https://frcmaven.wpi.edu/artifactory/release/edu/wpi/first/ntcore/ntcore-cpp/{0}/ntcore-cpp-{0}-linuxathenastatic.zip".format(WPILIB_VERSION)],
-    build_file="//third_party/wpilibsuite:ntcore.BUILD",
+    name = "ntcore",
+    build_file = "//third_party/wpilibsuite:ntcore.BUILD",
+    urls = ["https://frcmaven.wpi.edu/artifactory/release/edu/wpi/first/ntcore/ntcore-cpp/{0}/ntcore-cpp-{0}-linuxathenastatic.zip".format(WPILIB_VERSION)],
 )
 
 http_archive(
-    name="cameraserver_hdrs",
-    urls=["https://frcmaven.wpi.edu/artifactory/release/edu/wpi/first/cameraserver/cameraserver-cpp/{0}/cameraserver-cpp-{0}-headers.zip".format(WPILIB_VERSION)],
-    build_file_content=hdrs_content,
+    name = "cameraserver_hdrs",
+    build_file_content = hdrs_content,
+    urls = ["https://frcmaven.wpi.edu/artifactory/release/edu/wpi/first/cameraserver/cameraserver-cpp/{0}/cameraserver-cpp-{0}-headers.zip".format(WPILIB_VERSION)],
 )
 
 http_archive(
-    name="cameraserver",
-    urls=["https://frcmaven.wpi.edu/artifactory/release/edu/wpi/first/cameraserver/cameraserver-cpp/{0}/cameraserver-cpp-{0}-linuxathenastatic.zip".format(WPILIB_VERSION)],
-    build_file="//third_party/wpilibsuite:cameraserver.BUILD",
+    name = "cameraserver",
+    build_file = "//third_party/wpilibsuite:cameraserver.BUILD",
+    urls = ["https://frcmaven.wpi.edu/artifactory/release/edu/wpi/first/cameraserver/cameraserver-cpp/{0}/cameraserver-cpp-{0}-linuxathenastatic.zip".format(WPILIB_VERSION)],
 )
 
 http_archive(
-    name="cscore_hdrs",
-    urls=["https://frcmaven.wpi.edu/artifactory/release/edu/wpi/first/cscore/cscore-cpp/{0}/cscore-cpp-{0}-headers.zip".format(WPILIB_VERSION)],
-    build_file_content=hdrs_content,
+    name = "cscore_hdrs",
+    build_file_content = hdrs_content,
+    urls = ["https://frcmaven.wpi.edu/artifactory/release/edu/wpi/first/cscore/cscore-cpp/{0}/cscore-cpp-{0}-headers.zip".format(WPILIB_VERSION)],
 )
 
 http_archive(
-    name="cscore",
-    urls=["https://frcmaven.wpi.edu/artifactory/release/edu/wpi/first/cscore/cscore-cpp/{0}/cscore-cpp-{0}-linuxathenastatic.zip".format(WPILIB_VERSION)],
-    build_file="//third_party/wpilibsuite:cscore.BUILD",
+    name = "cscore",
+    build_file = "//third_party/wpilibsuite:cscore.BUILD",
+    urls = ["https://frcmaven.wpi.edu/artifactory/release/edu/wpi/first/cscore/cscore-cpp/{0}/cscore-cpp-{0}-linuxathenastatic.zip".format(WPILIB_VERSION)],
 )
 
 http_archive(
-    name="ctre_phoenix_api_cpp_hdrs",
-    urls=["https://devsite.ctr-electronics.com/maven/release/com/ctre/phoenix/api-cpp/{0}/api-cpp-{0}-headers.zip".format(CTRE_LIB_VERSION)],
-    build_file_content=hdrs_content,
+    name = "ctre_phoenix_api_cpp_hdrs",
+    build_file_content = hdrs_content,
+    urls = ["https://devsite.ctr-electronics.com/maven/release/com/ctre/phoenix/api-cpp/{0}/api-cpp-{0}-headers.zip".format(CTRE_LIB_VERSION)],
 )
 
 http_archive(
-    name="ctre_phoenix_api_cpp",
-    urls=["https://devsite.ctr-electronics.com/maven/release/com/ctre/phoenix/api-cpp/{0}/api-cpp-{0}-linuxathenastatic.zip".format(CTRE_LIB_VERSION)],
-    build_file="//third_party/ctre/phoenix:api_cpp.BUILD",
+    name = "ctre_phoenix_api_cpp",
+    build_file = "//third_party/ctre/phoenix:api_cpp.BUILD",
+    urls = ["https://devsite.ctr-electronics.com/maven/release/com/ctre/phoenix/api-cpp/{0}/api-cpp-{0}-linuxathenastatic.zip".format(CTRE_LIB_VERSION)],
 )
 
 http_archive(
-    name="ctre_phoenix_core_hdrs",
-    urls=["https://devsite.ctr-electronics.com/maven/release/com/ctre/phoenix/core/{0}/core-{0}-headers.zip".format(CTRE_LIB_VERSION)],
-    build_file_content=hdrs_content,
+    name = "ctre_phoenix_core_hdrs",
+    build_file_content = hdrs_content,
+    urls = ["https://devsite.ctr-electronics.com/maven/release/com/ctre/phoenix/core/{0}/core-{0}-headers.zip".format(CTRE_LIB_VERSION)],
 )
 
 http_archive(
-    name="ctre_phoenix_core",
-    urls=["https://devsite.ctr-electronics.com/maven/release/com/ctre/phoenix/core/{0}/core-{0}-linuxathenastatic.zip".format(CTRE_LIB_VERSION)],
-    build_file="//third_party/ctre/phoenix:core.BUILD",
+    name = "ctre_phoenix_core",
+    build_file = "//third_party/ctre/phoenix:core.BUILD",
+    urls = ["https://devsite.ctr-electronics.com/maven/release/com/ctre/phoenix/core/{0}/core-{0}-linuxathenastatic.zip".format(CTRE_LIB_VERSION)],
 )
 
 http_archive(
-    name="ctre_phoenix_cci_hdrs",
-    urls=["https://devsite.ctr-electronics.com/maven/release/com/ctre/phoenix/cci/{0}/cci-{0}-headers.zip".format(CTRE_LIB_VERSION)],
-    build_file_content=hdrs_content,
+    name = "ctre_phoenix_cci_hdrs",
+    build_file_content = hdrs_content,
+    urls = ["https://devsite.ctr-electronics.com/maven/release/com/ctre/phoenix/cci/{0}/cci-{0}-headers.zip".format(CTRE_LIB_VERSION)],
 )
 
 http_archive(
-    name="ctre_phoenix_cci",
-    urls=["https://devsite.ctr-electronics.com/maven/release/com/ctre/phoenix/cci/{0}/cci-{0}-linuxathenastatic.zip".format(CTRE_LIB_VERSION)],
-    build_file="//third_party/ctre/phoenix:cci.BUILD",
+    name = "ctre_phoenix_cci",
+    build_file = "//third_party/ctre/phoenix:cci.BUILD",
+    urls = ["https://devsite.ctr-electronics.com/maven/release/com/ctre/phoenix/cci/{0}/cci-{0}-linuxathenastatic.zip".format(CTRE_LIB_VERSION)],
 )
 
 http_archive(
-    name="ctre_phoenix_wpiapi_cpp_hdrs",
-    urls=["https://devsite.ctr-electronics.com/maven/release/com/ctre/phoenix/wpiapi-cpp/{0}/wpiapi-cpp-{0}-headers.zip".format(CTRE_LIB_VERSION)],
-    build_file_content=hdrs_content,
+    name = "ctre_phoenix_wpiapi_cpp_hdrs",
+    build_file_content = hdrs_content,
+    urls = ["https://devsite.ctr-electronics.com/maven/release/com/ctre/phoenix/wpiapi-cpp/{0}/wpiapi-cpp-{0}-headers.zip".format(CTRE_LIB_VERSION)],
 )
 
 http_archive(
-    name="ctre_phoenix_wpiapi_cpp",
-    urls=["https://devsite.ctr-electronics.com/maven/release/com/ctre/phoenix/wpiapi-cpp/{0}/wpiapi-cpp-{0}-linuxathenastatic.zip".format(CTRE_LIB_VERSION)],
-    build_file="//third_party/ctre/phoenix:wpiapi_cpp.BUILD",
+    name = "ctre_phoenix_wpiapi_cpp",
+    build_file = "//third_party/ctre/phoenix:wpiapi_cpp.BUILD",
+    urls = ["https://devsite.ctr-electronics.com/maven/release/com/ctre/phoenix/wpiapi-cpp/{0}/wpiapi-cpp-{0}-linuxathenastatic.zip".format(CTRE_LIB_VERSION)],
 )
 
 http_archive(
-    name="ni_libraries_netcomm_hdrs",
-    urls=["https://frcmaven.wpi.edu/artifactory/release/edu/wpi/first/ni-libraries/netcomm/{0}/netcomm-{0}-headers.zip".format(NI_LIB_VERSION)],
-    build_file_content=hdrs_content,
+    name = "ni_libraries_netcomm_hdrs",
+    build_file_content = hdrs_content,
+    urls = ["https://frcmaven.wpi.edu/artifactory/release/edu/wpi/first/ni-libraries/netcomm/{0}/netcomm-{0}-headers.zip".format(NI_LIB_VERSION)],
 )
 
 http_archive(
-    name="ni_libraries_netcomm",
-    urls=["https://frcmaven.wpi.edu/artifactory/release/edu/wpi/first/ni-libraries/netcomm/{0}/netcomm-{0}-linuxathena.zip".format(NI_LIB_VERSION)],
-    build_file="//third_party/ni_libraries:netcomm.BUILD",
+    name = "ni_libraries_netcomm",
+    build_file = "//third_party/ni_libraries:netcomm.BUILD",
+    urls = ["https://frcmaven.wpi.edu/artifactory/release/edu/wpi/first/ni-libraries/netcomm/{0}/netcomm-{0}-linuxathena.zip".format(NI_LIB_VERSION)],
 )
 
 http_archive(
-    name="ni_libraries_chipobject_hdrs",
-    urls=["https://frcmaven.wpi.edu/artifactory/release/edu/wpi/first/ni-libraries/chipobject/{0}/chipobject-{0}-headers.zip".format(NI_LIB_VERSION)],
-    build_file_content=hdrs_content,
+    name = "ni_libraries_chipobject_hdrs",
+    build_file_content = hdrs_content,
+    urls = ["https://frcmaven.wpi.edu/artifactory/release/edu/wpi/first/ni-libraries/chipobject/{0}/chipobject-{0}-headers.zip".format(NI_LIB_VERSION)],
 )
 
 http_archive(
-    name="ni_libraries_chipobject",
-    urls=["https://frcmaven.wpi.edu/artifactory/release/edu/wpi/first/ni-libraries/chipobject/{0}/chipobject-{0}-linuxathena.zip".format(NI_LIB_VERSION)],
-    build_file="//third_party/ni_libraries:chipobject.BUILD",
+    name = "ni_libraries_chipobject",
+    build_file = "//third_party/ni_libraries:chipobject.BUILD",
+    urls = ["https://frcmaven.wpi.edu/artifactory/release/edu/wpi/first/ni-libraries/chipobject/{0}/chipobject-{0}-linuxathena.zip".format(NI_LIB_VERSION)],
 )
 
 http_archive(
-    name="ni_libraries_runtime",
-    urls=["https://frcmaven.wpi.edu/artifactory/release/edu/wpi/first/ni-libraries/runtime/{0}/runtime-{0}-linuxathena.zip".format(NI_LIB_VERSION)],
-    build_file="//third_party/ni_libraries:runtime.BUILD",
+    name = "ni_libraries_runtime",
+    build_file = "//third_party/ni_libraries:runtime.BUILD",
+    urls = ["https://frcmaven.wpi.edu/artifactory/release/edu/wpi/first/ni-libraries/runtime/{0}/runtime-{0}-linuxathena.zip".format(NI_LIB_VERSION)],
 )
 
 http_archive(
-    name="ni_libraries_visa_hdrs",
-    urls=["https://frcmaven.wpi.edu/artifactory/release/edu/wpi/first/ni-libraries/visa/{0}/visa-{0}-headers.zip".format(NI_LIB_VERSION)],
-    build_file_content=hdrs_content,
+    name = "ni_libraries_visa_hdrs",
+    build_file_content = hdrs_content,
+    urls = ["https://frcmaven.wpi.edu/artifactory/release/edu/wpi/first/ni-libraries/visa/{0}/visa-{0}-headers.zip".format(NI_LIB_VERSION)],
 )
 
 http_archive(
-    name="ni_libraries_visa",
-    urls=["https://frcmaven.wpi.edu/artifactory/release/edu/wpi/first/ni-libraries/visa/{0}/visa-{0}-linuxathena.zip".format(NI_LIB_VERSION)],
-    build_file="//third_party/ni_libraries:visa.BUILD",
+    name = "ni_libraries_visa",
+    build_file = "//third_party/ni_libraries:visa.BUILD",
+    urls = ["https://frcmaven.wpi.edu/artifactory/release/edu/wpi/first/ni-libraries/visa/{0}/visa-{0}-linuxathena.zip".format(NI_LIB_VERSION)],
 )
 
 http_archive(
-    name="opencv_hdrs",
-    urls=["https://frcmaven.wpi.edu/artifactory/release/edu/wpi/first/thirdparty/frc2020/opencv/opencv-cpp/{0}/opencv-cpp-{0}-headers.zip".format(OPEN_CV_VERSION)],
-    build_file_content=hdrs_content,
+    name = "opencv_hdrs",
+    build_file_content = hdrs_content,
+    urls = ["https://frcmaven.wpi.edu/artifactory/release/edu/wpi/first/thirdparty/frc2020/opencv/opencv-cpp/{0}/opencv-cpp-{0}-headers.zip".format(OPEN_CV_VERSION)],
 )
 
 http_archive(
-    name="opencv",
-    urls=["https://frcmaven.wpi.edu/artifactory/release/edu/wpi/first/thirdparty/frc2020/opencv/opencv-cpp/{0}/opencv-cpp-{0}-linuxathenastatic.zip".format(OPEN_CV_VERSION)],
-    build_file="//third_party/wpilibsuite:opencv.BUILD",
+    name = "opencv",
+    build_file = "//third_party/wpilibsuite:opencv.BUILD",
+    urls = ["https://frcmaven.wpi.edu/artifactory/release/edu/wpi/first/thirdparty/frc2020/opencv/opencv-cpp/{0}/opencv-cpp-{0}-linuxathenastatic.zip".format(OPEN_CV_VERSION)],
+)
+
+http_archive(
+    name = "bazel_gazelle",
+    sha256 = "be9296bfd64882e3c08e3283c58fcb461fa6dd3c171764fcc4cf322f60615a9b",
+    urls = [
+        "https://storage.googleapis.com/bazel-mirror/github.com/bazelbuild/bazel-gazelle/releases/download/0.18.1/bazel-gazelle-0.18.1.tar.gz",
+        "https://github.com/bazelbuild/bazel-gazelle/releases/download/0.18.1/bazel-gazelle-0.18.1.tar.gz",
+    ],
+)
+
+load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
+
+gazelle_dependencies()
+
+http_archive(
+    name = "com_google_protobuf",
+    strip_prefix = "protobuf-master",
+    urls = ["https://github.com/protocolbuffers/protobuf/archive/master.zip"],
+)
+
+load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
+
+protobuf_deps()
+
+http_archive(
+    name = "com_github_bazelbuild_buildtools",
+    strip_prefix = "buildtools-master",
+    url = "https://github.com/bazelbuild/buildtools/archive/master.zip",
 )

--- a/platforms/BUILD
+++ b/platforms/BUILD
@@ -1,0 +1,7 @@
+platform(
+    name = "roborio",
+    constraint_values = [
+        "@platforms//cpu:armv7",
+        "@platforms//os:linux",
+    ],
+)

--- a/src/BUILD
+++ b/src/BUILD
@@ -1,7 +1,14 @@
 # https://docs.bazel.build/versions/master/be/c-cpp.html#cc_binary
 cc_binary(
     name = "main",
-    srcs = ["main.cpp", "main.h"],
+    srcs = [
+        "main.cpp",
+        "main.h",
+    ],
     copts = [],
-    deps = ["@wpilibc//:wpilibc", "@ctre_phoenix_api_cpp//:ctre_phoenix_api_cpp", "@eigen//:eigen"],
+    deps = [
+        "@ctre_phoenix_api_cpp",
+        "@eigen",
+        "@wpilibc",
+    ],
 )

--- a/third_party/ctre/phoenix/api_cpp.BUILD
+++ b/third_party/ctre/phoenix/api_cpp.BUILD
@@ -1,12 +1,12 @@
 cc_library(
-    name="ctre_phoenix_api_cpp",
-    srcs=[
+    name = "ctre_phoenix_api_cpp",
+    srcs = [
         "linux/athena/static/libCTRE_Phoenix.a",
     ],
-    deps=[
+    visibility = ["//visibility:public"],
+    deps = [
         "@ctre_phoenix_api_cpp_hdrs//:hdrs",
-        "@ctre_phoenix_cci//:ctre_phoenix_cci",
-        "@ctre_phoenix_wpiapi_cpp//:ctre_phoenix_wpiapi_cpp",
+        "@ctre_phoenix_cci",
+        "@ctre_phoenix_wpiapi_cpp",
     ],
-    visibility=["//visibility:public"],
 )

--- a/third_party/ctre/phoenix/cci.BUILD
+++ b/third_party/ctre/phoenix/cci.BUILD
@@ -1,11 +1,11 @@
 cc_library(
-    name="ctre_phoenix_cci",
-    srcs=[
+    name = "ctre_phoenix_cci",
+    srcs = [
         "linux/athena/static/libCTRE_PhoenixCCI.a",
     ],
-    deps=[
+    visibility = ["//visibility:public"],
+    deps = [
         "@ctre_phoenix_cci_hdrs//:hdrs",
-        "@ctre_phoenix_core//:ctre_phoenix_core",
+        "@ctre_phoenix_core",
     ],
-    visibility=["//visibility:public"],
 )

--- a/third_party/ctre/phoenix/core.BUILD
+++ b/third_party/ctre/phoenix/core.BUILD
@@ -1,10 +1,10 @@
 cc_library(
-    name="ctre_phoenix_core",
-    srcs=[
+    name = "ctre_phoenix_core",
+    srcs = [
         "linux/athena/static/libCTRE_PhoenixCore.a",
     ],
-    deps=[
+    visibility = ["//visibility:public"],
+    deps = [
         "@ctre_phoenix_core_hdrs//:hdrs",
     ],
-    visibility=["//visibility:public"],
 )

--- a/third_party/ctre/phoenix/wpiapi_cpp.BUILD
+++ b/third_party/ctre/phoenix/wpiapi_cpp.BUILD
@@ -1,10 +1,10 @@
 cc_library(
-    name="ctre_phoenix_wpiapi_cpp",
-    srcs=[
+    name = "ctre_phoenix_wpiapi_cpp",
+    srcs = [
         "linux/athena/static/libCTRE_Phoenix_WPI.a",
     ],
-    deps=[
+    visibility = ["//visibility:public"],
+    deps = [
         "@ctre_phoenix_wpiapi_cpp_hdrs//:hdrs",
     ],
-    visibility=["//visibility:public"],
 )

--- a/third_party/eigen/eigen.BUILD
+++ b/third_party/eigen/eigen.BUILD
@@ -1,7 +1,7 @@
 cc_library(
-    name = 'eigen',
+    name = "eigen",
     srcs = [],
-    includes = ['.'],
-    hdrs = glob(['Eigen/**']),
-    visibility = ['//visibility:public'],
+    hdrs = glob(["Eigen/**"]),
+    includes = ["."],
+    visibility = ["//visibility:public"],
 )

--- a/third_party/ni_libraries/chipobject.BUILD
+++ b/third_party/ni_libraries/chipobject.BUILD
@@ -1,11 +1,11 @@
 cc_library(
-    name="ni_libraries_chipobject",
-    srcs=[
+    name = "ni_libraries_chipobject",
+    srcs = [
         "linux/athena/shared/libRoboRIO_FRC_ChipObject.so.20.0.0",
     ],
-    deps=[
+    visibility = ["//visibility:public"],
+    deps = [
         "@ni_libraries_chipobject_hdrs//:hdrs",
         "@ni_libraries_runtime//:ni_libraries_runtime_NiFpgaLv",
     ],
-    visibility=["//visibility:public"],
 )

--- a/third_party/ni_libraries/netcomm.BUILD
+++ b/third_party/ni_libraries/netcomm.BUILD
@@ -1,12 +1,12 @@
 cc_library(
-    name="ni_libraries_netcomm",
-    srcs=[
+    name = "ni_libraries_netcomm",
+    srcs = [
         "linux/athena/shared/libFRC_NetworkCommunication.so.20.0.0",
     ],
-    deps=[
+    visibility = ["//visibility:public"],
+    deps = [
+        "@ni_libraries_chipobject",
         "@ni_libraries_netcomm_hdrs//:hdrs",
-        "@ni_libraries_chipobject//:ni_libraries_chipobject",
         "@ni_libraries_runtime//:ni_libraries_runtime_nirio_emb_can",
     ],
-    visibility=["//visibility:public"],
 )

--- a/third_party/ni_libraries/runtime.BUILD
+++ b/third_party/ni_libraries/runtime.BUILD
@@ -1,78 +1,78 @@
 cc_library(
-    name="ni_libraries_runtime_nirio_emb_can",
-    srcs=[
+    name = "ni_libraries_runtime_nirio_emb_can",
+    srcs = [
         "linux/athena/shared/libnirio_emb_can.so.16.0.0",
     ],
-    deps=[
+    visibility = ["//visibility:public"],
+    deps = [
         ":ni_libraries_runtime_ni_emb",
     ],
-    visibility=["//visibility:public"],
 )
 
 cc_library(
-    name="ni_libraries_runtime_ni_emb",
-    srcs=[
+    name = "ni_libraries_runtime_ni_emb",
+    srcs = [
         "linux/athena/shared/libni_emb.so.12.0.0",
     ],
-    deps=[
+    visibility = ["//visibility:public"],
+    deps = [
         ":ni_libraries_runtime_ni_rtlog",
     ],
-    visibility=["//visibility:public"],
 )
 
 cc_library(
-    name="ni_libraries_runtime_ni_rtlog",
-    srcs=[
+    name = "ni_libraries_runtime_ni_rtlog",
+    srcs = [
         "linux/athena/shared/libni_rtlog.so.2.8.0",
     ],
-    visibility=["//visibility:public"],
+    visibility = ["//visibility:public"],
 )
 
 cc_library(
-    name="ni_libraries_runtime_NiFpgaLv",
-    srcs=[
+    name = "ni_libraries_runtime_NiFpgaLv",
+    srcs = [
         "linux/athena/shared/libNiFpgaLv.so.19.0.0",
     ],
-    deps=[
+    visibility = ["//visibility:public"],
+    deps = [
         ":ni_libraries_runtime_NiFpga",
-        "@hal//:hal"
+        "@hal",
     ],
-    visibility=["//visibility:public"],
 )
 
 cc_library(
-    name="ni_libraries_runtime_NiFpga",
-    srcs=[
+    name = "ni_libraries_runtime_NiFpga",
+    srcs = [
         "linux/athena/shared/libNiFpga.so.19.0.0",
     ],
-    deps=[
+    visibility = ["//visibility:public"],
+    deps = [
+        ":ni_libraries_runtime_NiRioSrv",
         ":ni_libraries_runtime_niriodevenum",
         ":ni_libraries_runtime_niriosession",
-        ":ni_libraries_runtime_NiRioSrv",
     ],
-    visibility=["//visibility:public"],
 )
 
 cc_library(
-    name="ni_libraries_runtime_niriodevenum",
-    srcs=[
+    name = "ni_libraries_runtime_niriodevenum",
+    srcs = [
         "linux/athena/shared/libniriodevenum.so.19.0.0",
     ],
-    visibility=["//visibility:public"],
+    visibility = ["//visibility:public"],
 )
 
 cc_library(
-    name="ni_libraries_runtime_niriosession",
-    srcs=[
+    name = "ni_libraries_runtime_niriosession",
+    srcs = [
         "linux/athena/shared/libniriosession.so.18.0.0",
     ],
-    visibility=["//visibility:public"],
+    visibility = ["//visibility:public"],
 )
 
 cc_library(
-    name="ni_libraries_runtime_NiRioSrv",
-    srcs=[
+    name = "ni_libraries_runtime_NiRioSrv",
+    srcs = [
         "linux/athena/shared/libNiRioSrv.so.19.0.0",
     ],
-    visibility=["//visibility:public"],
+    visibility = ["//visibility:public"],
 )

--- a/third_party/ni_libraries/visa.BUILD
+++ b/third_party/ni_libraries/visa.BUILD
@@ -1,10 +1,10 @@
 cc_library(
-    name="ni_libraries_visa",
-    srcs=[
+    name = "ni_libraries_visa",
+    srcs = [
         "linux/athena/shared/libvisa.so",
     ],
-    deps=[
+    visibility = ["//visibility:public"],
+    deps = [
         "@ni_libraries_visa_hdrs//:hdrs",
     ],
-    visibility=["//visibility:public"],
 )

--- a/third_party/roborio_toolchain/BUILD
+++ b/third_party/roborio_toolchain/BUILD
@@ -1,48 +1,119 @@
 load(":cc_toolchain_config.bzl", "cc_toolchain_config")
 
-cc_toolchain_suite(
-    name="roborio_toolchain_suite",
-    toolchains={
-        "darwin": ":roborio_toolchain",
-        "linux": ":roborio_toolchain",
-        "windows": ":roborio_toolchain",
-        "k8": ":roborio_toolchain"
-    },
-)
-
-filegroup(
-    name="roborio_toolchain_files",
-    srcs=select({
-        "@bazel_tools//src/conditions:darwin": glob(["darwin/**/*"]),
-        "@bazel_tools//src/conditions:linux_x86_64": glob(["linux/**/*"]),
-        "@bazel_tools//src/conditions:windows": glob(["windows/**/*"]),
-    }),
-)
-
-cc_toolchain(
-    name="roborio_toolchain",
-    toolchain_identifier="roborio-toolchain",
-    toolchain_config=":roborio_toolchain_config",
-    all_files=":roborio_toolchain_files",
-    ar_files=":roborio_toolchain_files",
-    as_files=":roborio_toolchain_files",
-    compiler_files=":roborio_toolchain_files",
-    dwp_files=":roborio_toolchain_files",
-    linker_files=":roborio_toolchain_files",
-    objcopy_files=":roborio_toolchain_files",
-    strip_files=":roborio_toolchain_files",
-    supports_param_files=False,
+cc_toolchain_config(
+    name = "roborio_toolchain_config_darwin",
+    path_prefix = "darwin/frc2020/roborio",
 )
 
 cc_toolchain_config(
-    name="roborio_toolchain_config",
-    path_prefix=select({
-        "@bazel_tools//src/conditions:darwin": "darwin/frc2020/roborio",
-        "@bazel_tools//src/conditions:linux_x86_64": "linux/frc2020/roborio",
-        "@bazel_tools//src/conditions:windows": "windows/frc2020/roborio",
-    }),
-    path_suffix=select({
-        "@bazel_tools//src/conditions:windows": ".exe",
-        "//conditions:default": "",
-    }),
+    name = "roborio_toolchain_config_linux",
+    path_prefix = "linux/frc2020/roborio",
+)
+
+cc_toolchain_config(
+    name = "roborio_toolchain_config_windows",
+    path_prefix = "windows/frc2020/roborio",
+    path_suffix = ".exe",
+)
+
+filegroup(
+    name = "roborio_toolchain_files_darwin",
+    srcs = glob(["darwin/**/*"]),
+)
+
+filegroup(
+    name = "roborio_toolchain_files_linux",
+    srcs = glob(["linux/**/*"]),
+)
+
+filegroup(
+    name = "roborio_toolchain_files_windows",
+    srcs = glob(["windows/**/*"]),
+)
+
+cc_toolchain(
+    name = "roborio_cc_toolchain_darwin",
+    all_files = ":roborio_toolchain_files_darwin",
+    ar_files = ":roborio_toolchain_files_darwin",
+    as_files = ":roborio_toolchain_files_darwin",
+    compiler_files = ":roborio_toolchain_files_darwin",
+    dwp_files = ":roborio_toolchain_files_darwin",
+    linker_files = ":roborio_toolchain_files_darwin",
+    objcopy_files = ":roborio_toolchain_files_darwin",
+    strip_files = ":roborio_toolchain_files_darwin",
+    supports_param_files = False,
+    toolchain_config = ":roborio_toolchain_config_darwin",
+    toolchain_identifier = "roborio-toolchain",
+)
+
+cc_toolchain(
+    name = "roborio_cc_toolchain_linux",
+    all_files = ":roborio_toolchain_files_linux",
+    ar_files = ":roborio_toolchain_files_linux",
+    as_files = ":roborio_toolchain_files_linux",
+    compiler_files = ":roborio_toolchain_files_linux",
+    dwp_files = ":roborio_toolchain_files_linux",
+    linker_files = ":roborio_toolchain_files_linux",
+    objcopy_files = ":roborio_toolchain_files_linux",
+    strip_files = ":roborio_toolchain_files_linux",
+    supports_param_files = False,
+    toolchain_config = ":roborio_toolchain_config_linux",
+    toolchain_identifier = "roborio-toolchain",
+)
+
+cc_toolchain(
+    name = "roborio_cc_toolchain_windows",
+    all_files = ":roborio_toolchain_files_windows",
+    ar_files = ":roborio_toolchain_files_windows",
+    as_files = ":roborio_toolchain_files_windows",
+    compiler_files = ":roborio_toolchain_files_windows",
+    dwp_files = ":roborio_toolchain_files_windows",
+    linker_files = ":roborio_toolchain_files_windows",
+    objcopy_files = ":roborio_toolchain_files_windows",
+    strip_files = ":roborio_toolchain_files_windows",
+    supports_param_files = False,
+    toolchain_config = ":roborio_toolchain_config_windows",
+    toolchain_identifier = "roborio-toolchain",
+)
+
+toolchain(
+    name = "roborio_toolchain_darwin",
+    exec_compatible_with = [
+        "@platforms//cpu:x86_64",
+        "@platforms//os:macos",
+    ],
+    target_compatible_with = [
+        "@platforms//cpu:armv7",
+        "@platforms//os:linux",
+    ],
+    toolchain = ":roborio_cc_toolchain_darwin",
+    toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
+)
+
+toolchain(
+    name = "roborio_toolchain_linux",
+    exec_compatible_with = [
+        "@platforms//cpu:x86_64",
+        "@platforms//os:linux",
+    ],
+    target_compatible_with = [
+        "@platforms//cpu:armv7",
+        "@platforms//os:linux",
+    ],
+    toolchain = ":roborio_cc_toolchain_linux",
+    toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
+)
+
+toolchain(
+    name = "roborio_toolchain_windows",
+    exec_compatible_with = [
+        "@platforms//cpu:x86_64",
+        "@platforms//os:windows",
+    ],
+    target_compatible_with = [
+        "@platforms//cpu:armv7",
+        "@platforms//os:linux",
+    ],
+    toolchain = ":roborio_cc_toolchain_windows",
+    toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
 )

--- a/third_party/roborio_toolchain/cc_toolchain_config.bzl
+++ b/third_party/roborio_toolchain/cc_toolchain_config.bzl
@@ -13,45 +13,45 @@ load(
 def _impl(ctx):
     tool_paths = [
         tool_path(
-            name="ar",
-            path="{}/bin/arm-frc2020-linux-gnueabi-ar{}".format(ctx.attr.path_prefix, ctx.attr.path_suffix),
+            name = "ar",
+            path = "{}/bin/arm-frc2020-linux-gnueabi-ar{}".format(ctx.attr.path_prefix, ctx.attr.path_suffix),
         ),
         tool_path(
-            name="cpp",
-            path="{}/bin/arm-frc2020-linux-gnueabi-cpp{}".format(ctx.attr.path_prefix, ctx.attr.path_suffix),
+            name = "cpp",
+            path = "{}/bin/arm-frc2020-linux-gnueabi-cpp{}".format(ctx.attr.path_prefix, ctx.attr.path_suffix),
         ),
         tool_path(
-            name="gcc",
-            path="{}/bin/arm-frc2020-linux-gnueabi-gcc{}".format(ctx.attr.path_prefix, ctx.attr.path_suffix),
+            name = "gcc",
+            path = "{}/bin/arm-frc2020-linux-gnueabi-gcc{}".format(ctx.attr.path_prefix, ctx.attr.path_suffix),
         ),
         tool_path(
-            name="gcov",
-            path="{}/bin/arm-frc2020-linux-gnueabi-gcov{}".format(ctx.attr.path_prefix, ctx.attr.path_suffix),
+            name = "gcov",
+            path = "{}/bin/arm-frc2020-linux-gnueabi-gcov{}".format(ctx.attr.path_prefix, ctx.attr.path_suffix),
         ),
         tool_path(
-            name="ld",
-            path="{}/bin/arm-frc2020-linux-gnueabi-ld{}".format(ctx.attr.path_prefix, ctx.attr.path_suffix),
+            name = "ld",
+            path = "{}/bin/arm-frc2020-linux-gnueabi-ld{}".format(ctx.attr.path_prefix, ctx.attr.path_suffix),
         ),
         tool_path(
-            name="nm",
-            path="{}/bin/arm-frc2020-linux-gnueabi-nm{}".format(ctx.attr.path_prefix, ctx.attr.path_suffix),
+            name = "nm",
+            path = "{}/bin/arm-frc2020-linux-gnueabi-nm{}".format(ctx.attr.path_prefix, ctx.attr.path_suffix),
         ),
         tool_path(
-            name="objdump",
-            path="{}/bin/arm-frc2020-linux-gnueabi-objdump{}".format(ctx.attr.path_prefix, ctx.attr.path_suffix),
+            name = "objdump",
+            path = "{}/bin/arm-frc2020-linux-gnueabi-objdump{}".format(ctx.attr.path_prefix, ctx.attr.path_suffix),
         ),
         tool_path(
-            name="strip",
-            path="{}/bin/arm-frc2020-linux-gnueabi-strip{}".format(ctx.attr.path_prefix, ctx.attr.path_suffix),
+            name = "strip",
+            path = "{}/bin/arm-frc2020-linux-gnueabi-strip{}".format(ctx.attr.path_prefix, ctx.attr.path_suffix),
         ),
     ]
 
     toolchain_include_directories_feature = feature(
-        name="toolchain-include-directories",
-        enabled=True,
-        flag_sets=[
+        name = "toolchain-include-directories",
+        enabled = True,
+        flag_sets = [
             flag_set(
-                actions=[
+                actions = [
                     ACTION_NAMES.c_compile,
                     ACTION_NAMES.cpp_compile,
                     ACTION_NAMES.linkstamp_compile,
@@ -63,9 +63,9 @@ def _impl(ctx):
                     ACTION_NAMES.lto_backend,
                     ACTION_NAMES.clif_match,
                 ],
-                flag_groups=[
+                flag_groups = [
                     flag_group(
-                        flags=[
+                        flags = [
                             "-no-canonical-prefixes",
                             "-std=c++17",
                             "-Wno-psabi",
@@ -74,14 +74,12 @@ def _impl(ctx):
                 ],
             ),
             flag_set(
-                actions=[
+                actions = [
                     ACTION_NAMES.cpp_link_executable,
                 ],
-                flag_groups=[
+                flag_groups = [
                     flag_group(
-                        flags=[
-                            "-lm",
-                            "-lpthread",
+                        flags = [
                             "-lstdc++",
                         ],
                     ),
@@ -91,27 +89,27 @@ def _impl(ctx):
     )
 
     return cc_common.create_cc_toolchain_config_info(
-        ctx=ctx,
-        toolchain_identifier="roborio-toolchain",
-        host_system_name="unknown", # TODO: should this be customizable?
-        target_system_name="arm-frc2020-linux-gnueabi",
-        target_cpu="armv7",
-        target_libc="gnueabi",
-        compiler="gcc",
-        abi_version="unknown",
-        abi_libc_version="unknown",
-        tool_paths=tool_paths,
-        builtin_sysroot="third_party/roborio_toolchain/{}/arm-frc2020-linux-gnueabi".format(
+        ctx = ctx,
+        toolchain_identifier = "roborio-toolchain",
+        host_system_name = "unknown",  # TODO: should this be customizable?
+        target_system_name = "arm-frc2020-linux-gnueabi",
+        target_cpu = "armv7",
+        target_libc = "gnueabi",
+        compiler = "gcc",
+        abi_version = "unknown",
+        abi_libc_version = "unknown",
+        tool_paths = tool_paths,
+        builtin_sysroot = "third_party/roborio_toolchain/{}/arm-frc2020-linux-gnueabi".format(
             ctx.attr.path_prefix,
         ),
-        features=[toolchain_include_directories_feature],
+        features = [toolchain_include_directories_feature],
     )
 
 cc_toolchain_config = rule(
-    implementation=_impl,
-    attrs={
-        "path_prefix": attr.string(default="", mandatory=False),
-        "path_suffix": attr.string(default="", mandatory=False),
+    implementation = _impl,
+    attrs = {
+        "path_prefix": attr.string(default = "", mandatory = False),
+        "path_suffix": attr.string(default = "", mandatory = False),
     },
-    provides=[CcToolchainConfigInfo],
+    provides = [CcToolchainConfigInfo],
 )

--- a/third_party/wpilibsuite/cameraserver.BUILD
+++ b/third_party/wpilibsuite/cameraserver.BUILD
@@ -1,11 +1,11 @@
 cc_library(
-    name="cameraserver",
-    srcs=[
+    name = "cameraserver",
+    srcs = [
         "linux/athena/static/libcameraserver.a",
     ],
-    deps=[
+    visibility = ["//visibility:public"],
+    deps = [
         "@cameraserver_hdrs//:hdrs",
-        "@cscore//:cscore",
+        "@cscore",
     ],
-    visibility=["//visibility:public"],
 )

--- a/third_party/wpilibsuite/cscore.BUILD
+++ b/third_party/wpilibsuite/cscore.BUILD
@@ -1,12 +1,12 @@
 cc_library(
-    name="cscore",
-    srcs=[
+    name = "cscore",
+    srcs = [
         "linux/athena/static/libcscore.a",
     ],
-    deps=[
+    visibility = ["//visibility:public"],
+    deps = [
         "@cscore_hdrs//:hdrs",
-        "@wpiutil//:wpiutil",
-        "@opencv//:opencv",
+        "@opencv",
+        "@wpiutil",
     ],
-    visibility=["//visibility:public"],
 )

--- a/third_party/wpilibsuite/hal.BUILD
+++ b/third_party/wpilibsuite/hal.BUILD
@@ -1,12 +1,13 @@
 cc_library(
-    name="hal",
-    srcs=[
+    name = "hal",
+    srcs = [
         "linux/athena/static/libwpiHal.a",
     ],
-    deps=[
+    linkopts = ["-lm"],
+    visibility = ["//visibility:public"],
+    deps = [
         "@hal_hdrs//:hdrs",
-        "@wpiutil//:wpiutil",
-        "@ni_libraries_visa//:ni_libraries_visa",
+        "@ni_libraries_visa",
+        "@wpiutil",
     ],
-    visibility=["//visibility:public"],
 )

--- a/third_party/wpilibsuite/ntcore.BUILD
+++ b/third_party/wpilibsuite/ntcore.BUILD
@@ -1,11 +1,11 @@
 cc_library(
-    name="ntcore",
-    srcs=[
+    name = "ntcore",
+    srcs = [
         "linux/athena/static/libntcore.a",
     ],
-    deps=[
+    visibility = ["//visibility:public"],
+    deps = [
         "@ntcore_hdrs//:hdrs",
-        "@wpiutil//:wpiutil",
+        "@wpiutil",
     ],
-    visibility=["//visibility:public"],
 )

--- a/third_party/wpilibsuite/opencv.BUILD
+++ b/third_party/wpilibsuite/opencv.BUILD
@@ -1,10 +1,10 @@
 cc_library(
-    name="opencv",
-    srcs=[
+    name = "opencv",
+    srcs = [
         "linux/athena/static/libopencv347.a",
     ],
-    deps=[
+    visibility = ["//visibility:public"],
+    deps = [
         "@opencv_hdrs//:hdrs",
     ],
-    visibility=["//visibility:public"],
 )

--- a/third_party/wpilibsuite/wpilibc.BUILD
+++ b/third_party/wpilibsuite/wpilibc.BUILD
@@ -1,14 +1,14 @@
 cc_library(
-    name="wpilibc",
-    srcs=[
+    name = "wpilibc",
+    srcs = [
         "linux/athena/static/libwpilibc.a",
     ],
-    deps=[
+    visibility = ["//visibility:public"],
+    deps = [
+        "@cameraserver",
+        "@hal",
+        "@ni_libraries_netcomm",
+        "@ntcore",
         "@wpilibc_hdrs//:hdrs",
-        "@hal//:hal",
-        "@ntcore//:ntcore",
-        "@cameraserver//:cameraserver",
-        "@ni_libraries_netcomm//:ni_libraries_netcomm",
     ],
-    visibility=["//visibility:public"],
 )

--- a/third_party/wpilibsuite/wpiutil.BUILD
+++ b/third_party/wpilibsuite/wpiutil.BUILD
@@ -1,10 +1,11 @@
 cc_library(
-    name="wpiutil",
-    srcs=[
+    name = "wpiutil",
+    srcs = [
         "linux/athena/static/libwpiutil.a",
     ],
-    deps=[
+    linkopts = ["-lpthread"],
+    visibility = ["//visibility:public"],
+    deps = [
         "@wpiutil_hdrs//:hdrs",
     ],
-    visibility=["//visibility:public"],
 )

--- a/third_party/zeromq/cppzmq.BUILD
+++ b/third_party/zeromq/cppzmq.BUILD
@@ -1,6 +1,9 @@
 cc_library(
     name = "cppzmq",
-    hdrs = ["zmq.hpp", "zmq_addon.hpp"],
-    deps = ["@libzmq//:libzmq"],
-    visibility = ['//visibility:public']
+    hdrs = [
+        "zmq.hpp",
+        "zmq_addon.hpp",
+    ],
+    visibility = ["//visibility:public"],
+    deps = ["@libzmq"],
 )

--- a/third_party/zeromq/libzmq.BUILD
+++ b/third_party/zeromq/libzmq.BUILD
@@ -1,7 +1,7 @@
 cc_library(
     name = "libzmq",
-    includes = ['include/'],
-    hdrs = glob(["include/*.h"]) + glob(["src/**/*.h"]) + glob(["src/**/*.hpp"]),
     srcs = glob(["src/**/*.cpp"]),
-    visibility = ['//visibility:public']
+    hdrs = glob(["include/*.h"]) + glob(["src/**/*.h"]) + glob(["src/**/*.hpp"]),
+    includes = ["include/"],
+    visibility = ["//visibility:public"],
 )

--- a/third_party/zeromq/pyzmq.BUILD
+++ b/third_party/zeromq/pyzmq.BUILD
@@ -1,3 +1,3 @@
 py_library(
-    name = "pyzmq"
+    name = "pyzmq",
 )

--- a/tools/buildifier/BUILD
+++ b/tools/buildifier/BUILD
@@ -1,0 +1,5 @@
+load("@com_github_bazelbuild_buildtools//buildifier:def.bzl", "buildifier")
+
+buildifier(
+    name = "buildifier",
+)


### PR DESCRIPTION
Apparently [platforms are the future](https://docs.bazel.build/versions/2.0.0/platforms-intro.html), so let's use them.